### PR TITLE
DButton: Provide deprecated support for string-based actions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.js
+++ b/app/assets/javascripts/discourse/app/components/d-button.js
@@ -1,15 +1,17 @@
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 import { empty, equal, notEmpty } from "@ember/object/computed";
-import Component from "@glimmer/component";
+import GlimmerComponentWithDeprecatedParentView from "discourse/components/glimmer-component-with-deprecated-parent-view";
 import deprecated from "discourse-common/lib/deprecated";
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 
-const ACTION_AS_STRING_DEPRECATION =
-  "DButton no longer supports @action as a string. Please refactor to use an closure action instead.";
+const ACTION_AS_STRING_DEPRECATION_ARGS = [
+  "DButton no longer supports @action as a string. Please refactor to use an closure action instead.",
+  { id: "discourse.d-button-action-string" },
+];
 
-export default class DButton extends Component {
+export default class DButton extends GlimmerComponentWithDeprecatedParentView {
   @service router;
 
   @notEmpty("args.icon")
@@ -24,7 +26,7 @@ export default class DButton extends Component {
   constructor() {
     super(...arguments);
     if (typeof this.args.action === "string") {
-      deprecated(ACTION_AS_STRING_DEPRECATION);
+      deprecated(...ACTION_AS_STRING_DEPRECATION_ARGS);
     }
   }
 
@@ -106,7 +108,14 @@ export default class DButton extends Component {
         const { actionParam, forwardEvent } = this.args;
 
         if (typeof actionVal === "string") {
-          throw new Error(ACTION_AS_STRING_DEPRECATION);
+          deprecated(...ACTION_AS_STRING_DEPRECATION_ARGS);
+          if (this.parentView?.send) {
+            this.parentView.send(actionVal, actionParam);
+          } else {
+            throw new Error(
+              "DButton could not find a target for the action. Use a closure action instead"
+            );
+          }
         } else if (typeof actionVal === "object" && actionVal.value) {
           if (forwardEvent) {
             actionVal.value(actionParam, event);

--- a/app/assets/javascripts/discourse/app/components/glimmer-component-with-deprecated-parent-view.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer-component-with-deprecated-parent-view.js
@@ -1,0 +1,32 @@
+import Component from "@glimmer/component";
+import {
+  CustomComponentManager,
+  setInternalComponentManager,
+} from "@glimmer/manager";
+import EmberGlimmerComponentManager from "@glimmer/component/-private/ember-component-manager";
+
+class GlimmerComponentWithParentViewManager extends CustomComponentManager {
+  create(owner, componentClass, args, environment, dynamicScope) {
+    const result = super.create(...arguments);
+
+    result.component.parentView = dynamicScope.view;
+    dynamicScope.view = result.component;
+
+    return result;
+  }
+}
+
+/**
+ * This component has a lightly-extended version of Ember's default Glimmer component manager.
+ * It gives Glimmer components the ability to reference their parent view which can be useful
+ * when building backwards-compatible versions of components. Any use of the parentView property
+ * of the component should be considered deprecated.
+ */
+export default class GlimmerComponentWithDeprecatedParentView extends Component {}
+
+setInternalComponentManager(
+  new GlimmerComponentWithParentViewManager(
+    (owner) => new EmberGlimmerComponentManager(owner)
+  ),
+  GlimmerComponentWithDeprecatedParentView
+);

--- a/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
@@ -4,6 +4,7 @@ import { click, render, triggerKeyEvent } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { hbs } from "ember-cli-htmlbars";
+import ClassicComponent from "@ember/component";
 
 module("Integration | Component | d-button", function (hooks) {
   setupRenderingTest(hooks);
@@ -249,6 +250,30 @@ module("Integration | Component | d-button", function (hooks) {
     });
 
     await render(hbs`<DButton @action={{this.action}} />`);
+
+    await click(".btn");
+
+    assert.strictEqual(this.foo, "bar");
+  });
+
+  test("@action can sendAction when passed a string", async function (assert) {
+    this.set("foo", null);
+    this.set("legacyActionTriggered", () => this.set("foo", "bar"));
+
+    this.classicComponent = ClassicComponent.extend({
+      actions: {
+        myLegacyAction() {
+          this.legacyActionTriggered();
+        },
+      },
+    });
+
+    await render(
+      hbs`<this.classicComponent @legacyActionTriggered={{this.legacyActionTriggered}}>
+          <DButton @action="myLegacyAction" />
+        </this.classicComponent>
+        `
+    );
 
     await click(".btn");
 


### PR DESCRIPTION
This is achieved through the use of a custom component manager

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
